### PR TITLE
Implement writing to `logs` from custom R Callbacks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@ New Features:
 
 - Added activation functions swish and gelu. (#1226)
 - `set_vocabulary()` gains a `idf_weights` argument.
+- Callbacks can now add custom metrics to the fit history. (#1230) by @AshesITR
 
 # keras 2.4.0
 

--- a/R/callbacks.R
+++ b/R/callbacks.R
@@ -521,6 +521,8 @@ callback_lambda <- function(on_epoch_begin = NULL, on_epoch_end = NULL,
 #' - `on_batch_begin`: logs include `size`, the number of samples in the current batch.
 #' - `on_batch_end`: logs include `loss`, and optionally `acc` (if accuracy monitoring is enabled).
 #'
+#' A callback can append custom metrics to the `logs` by returning a named `list` of metrics.
+#'
 #' @return [KerasCallback].
 #'
 #' @examples

--- a/inst/python/kerastools/callback.py
+++ b/inst/python/kerastools/callback.py
@@ -1,5 +1,4 @@
 
-
 import os
 
 if (os.getenv('KERAS_IMPLEMENTATION', 'tensorflow') == 'keras'):
@@ -50,50 +49,82 @@ class RCallback(Callback):
     self._chief_worker_only = False
 
   def on_epoch_begin(self, epoch, logs=None):
-    self.r_on_epoch_begin(epoch, logs)
+    out = self.r_on_epoch_begin(epoch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_epoch_end(self, epoch, logs=None):
-    self.r_on_epoch_end(epoch, logs)
+    out = self.r_on_epoch_end(epoch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_train_begin(self, logs=None):
     self.r_set_context(self.params, self.model)
-    self.r_on_train_begin(logs)
+    out = self.r_on_train_begin(logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_train_end(self, logs=None):
-    self.r_on_train_end(logs)
+    out = self.r_on_train_end(logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_batch_begin(self, batch, logs=None):
-    self.r_on_batch_begin(batch, logs)
+    out = self.r_on_batch_begin(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_batch_end(self, batch, logs=None):
-    self.r_on_batch_end(batch, logs)
+    out = self.r_on_batch_end(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_predict_batch_begin(self, batch, logs=None):
-    self.r_on_predict_batch_begin(batch, logs)
+    out = self.r_on_predict_batch_begin(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_predict_batch_end(self, batch, logs=None):
-    self.r_on_predict_batch_end(batch, logs)
+    out = self.r_on_predict_batch_end(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_predict_begin(self, logs=None):
-    self.r_on_predict_begin(logs)
+    out = self.r_on_predict_begin(logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_predict_end(self, logs=None):
-    self.r_on_predict_end(logs)
+    out = self.r_on_predict_end(logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_test_batch_begin(self, batch, logs=None):
-    self.r_on_test_batch_begin(batch, logs)
+    out = self.r_on_test_batch_begin(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_test_batch_end(self, batch, logs=None):
-    self.r_on_test_batch_end(batch, logs)
+    out = self.r_on_test_batch_end(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_test_begin(self, logs=None):
-    self.r_on_test_begin(logs)
+    out = self.r_on_test_begin(logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_test_end(self, logs=None):
-    self.r_on_test_end(logs)
+    out = self.r_on_test_end(logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_train_batch_begin(self, batch, logs=None):
-    self.r_on_train_batch_begin(batch, logs)
+    out = self.r_on_train_batch_begin(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)
 
   def on_train_batch_end(self, batch, logs=None):
-    self.r_on_train_batch_end(batch, logs)
+    out = self.r_on_train_batch_end(batch, logs)
+    if isinstance(out, dict) and isinstance(logs, dict):
+      logs.update(out)

--- a/man/KerasCallback.Rd
+++ b/man/KerasCallback.Rd
@@ -25,6 +25,8 @@ it passes to its callbacks:
 \item \code{on_batch_begin}: logs include \code{size}, the number of samples in the current batch.
 \item \code{on_batch_end}: logs include \code{loss}, and optionally \code{acc} (if accuracy monitoring is enabled).
 }
+
+A callback can append custom metrics to the \code{logs} by returning a named \code{list} of metrics.
 }
 \section{Fields}{
 

--- a/tests/testthat/test-callbacks.R
+++ b/tests/testthat/test-callbacks.R
@@ -142,13 +142,24 @@ test_succeeds("custom callbacks", {
 
     ))
 
+  CustomMetric <- R6::R6Class("CustomMetric",
+    inherit = KerasCallback,
+    public = list(
+      on_epoch_end = function(epoch, logs = list()) {
+        logs[["epoch"]] <- epoch
+        logs
+      }
+    )
+  )
+
   cc <- CustomCallback$new()
   lh <- LossHistory$new()
+  cm <- CustomMetric$new()
 
-  define_compile_and_fit(callbacks = list(cc, lh))
+  hist <- define_compile_and_fit(callbacks = list(cc, lh, cm))
 
   expect_is(lh$losses, "numeric")
-
+  expect_is(hist$metrics$epoch, "numeric")
 })
 
 


### PR DESCRIPTION
This fixes #1230 by updating the logs in a custom R Callback, if the R implementations return a (named) list.

I also added documentation, test and NEWS entry.
Please take a look and let me know if you want any changes, I'm not a python expert.